### PR TITLE
KDE Frameworks 5 ports: Use lookup for version instead of hardcoding …

### DIFF
--- a/Scripts/Ravenports_Mk/raven.information.mk
+++ b/Scripts/Ravenports_Mk/raven.information.mk
@@ -229,7 +229,6 @@ GSTREAMER1_GST=			1.0
 GSTREAMER1_SOVERSION=		0.2200.0
 XORG_VERSION=			7.7
 LLVM_VERSION=			15.0.7
-LLVM_13_VERSION=		13.0.1
 ZLIB_VERSION=			1.2.13
 GHOSTSCRIPT_VERSION=		10.00.0
 SPHINX_UNDERSCORE=		1.13.1
@@ -246,10 +245,11 @@ GNATCROSS_MIDNIGHTBSD_3=	12.3
 GNATCROSS_NETBSD_9=		9.2
 
 # ------------------------------------------------------------------------
-# Qt and Lumina versions
+# Qt and Qt-based desktops
 # ------------------------------------------------------------------------
 
 QT5_VERSION=			5.15.6
 QT6_VERSION=			6.4.2
 LUMINA_VERSION=			1.6.2
 LUMINA_RELEASE_TAG=		1.6.2
+KDE_FRAMEWORKS_VERSION=		5.102.0

--- a/bucket_04/kf5-attica/specification
+++ b/bucket_04/kf5-attica/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-attica
@@ -37,7 +36,7 @@ USES=			cmake
 
 DISTNAME=		attica-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/version.h.cmake':" > ${WRKDIR}/TERMS

--- a/bucket_0B/kf5-kwidgetsaddons/specification
+++ b/bucket_0B/kf5-kwidgetsaddons/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kwidgetsaddons
@@ -39,7 +38,7 @@ USES=			cmake
 
 DISTNAME=		kwidgetsaddons-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/kurllabel.h':" > ${WRKDIR}/TERMS

--- a/bucket_19/kf5-kcodecs/specification
+++ b/bucket_19/kf5-kcodecs/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kcodecs
@@ -44,7 +43,7 @@ USES=			cmake
 
 DISTNAME=		kcodecs-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/probers/nsSJISProber.h':" > ${WRKDIR}/TERMS

--- a/bucket_32/kf5-karchive/specification
+++ b/bucket_32/kf5-karchive/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-karchive
@@ -35,7 +34,7 @@ USES=			cmake pkgconfig zlib zstd bz2 xz
 
 DISTNAME=		karchive-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-stage:
 	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libKF5Archive.so

--- a/bucket_45/kf5-kded/specification
+++ b/bucket_45/kf5-kded/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kded
@@ -41,7 +40,7 @@ USES=			cmake
 
 DISTNAME=		kded-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/kded.h':" > ${WRKDIR}/TERMS

--- a/bucket_47/kf5-kglobalaccel/specification
+++ b/bucket_47/kf5-kglobalaccel/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kglobalaccel
@@ -45,7 +44,7 @@ USES=			cmake
 
 DISTNAME=		kglobalaccel-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/kglobalaccel.h':" > ${WRKDIR}/TERMS

--- a/bucket_60/kf5-kdoctools/specification
+++ b/bucket_60/kf5-kdoctools/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kdoctools
@@ -45,7 +44,7 @@ GNOME_COMPONENTS=	libxml2 libxslt
 
 DISTNAME=		kdoctools-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/customization/dtd/rdbhier2.elements':" > \

--- a/bucket_63/kf5-kwindowsystem/specification
+++ b/bucket_63/kf5-kwindowsystem/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kwindowsystem
@@ -40,7 +39,7 @@ USES=			cmake
 
 DISTNAME=		kwindowsystem-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/kwindowinfo.cpp':" > ${WRKDIR}/TERMS

--- a/bucket_74/kf5-kcompletion/specification
+++ b/bucket_74/kf5-kcompletion/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kcompletion
@@ -37,7 +36,7 @@ USES=			cmake
 
 DISTNAME=		kcompletion-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/klineedit.h':" > ${WRKDIR}/TERMS

--- a/bucket_75/kf5-kservice/specification
+++ b/bucket_75/kf5-kservice/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kservice
@@ -43,7 +42,7 @@ USES=			bison cmake gettext
 
 DISTNAME=		kservice-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/services/kservice.h':" > ${WRKDIR}/TERMS

--- a/bucket_77/kf5-kconfig/specification
+++ b/bucket_77/kf5-kconfig/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kconfig
@@ -48,7 +47,7 @@ CPE_VENDOR=		kde
 CPE_PRODUCT=		kconfig
 DISTNAME=		kconfig-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/core/kemailsettings.h':" > ${WRKDIR}/TERMS

--- a/bucket_85/kf5-extra-cmake-modules/specification
+++ b/bucket_85/kf5-extra-cmake-modules/specification
@@ -1,4 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-extra-cmake-modules

--- a/bucket_93/kf5-kauth/specification
+++ b/bucket_93/kf5-kauth/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kauth
@@ -38,7 +37,7 @@ CPE_VENDOR=		kde
 CPE_PRODUCT=		kauth
 DISTNAME=		kauth-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/objectdecorator.h':" > ${WRKDIR}/TERMS

--- a/bucket_A0/kf5-kjobwidgets/specification
+++ b/bucket_A0/kf5-kjobwidgets/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kjobwidgets
@@ -40,7 +39,7 @@ USES=			cmake
 
 DISTNAME=		kjobwidgets-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/kjobwidgets.cpp':" > ${WRKDIR}/TERMS

--- a/bucket_A2/kf5-kdbusaddons/specification
+++ b/bucket_A2/kf5-kdbusaddons/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kdbusaddons
@@ -38,7 +37,7 @@ USES=			cmake
 
 DISTNAME=		kdbusaddons-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/kdedmodule.h':" > ${WRKDIR}/TERMS

--- a/bucket_B2/kf5-ki18n/specification
+++ b/bucket_B2/kf5-ki18n/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-ki18n
@@ -39,7 +38,7 @@ USES=			cmake gettext python:build
 
 DISTNAME=		ki18n-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/i18n/main.cpp':" > \

--- a/bucket_B8/kf5-breeze-icons/specification
+++ b/bucket_B8/kf5-breeze-icons/specification
@@ -1,4 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-breeze-icons

--- a/bucket_CD/kf5-kitemviews/specification
+++ b/bucket_CD/kf5-kitemviews/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kitemviews
@@ -35,7 +34,7 @@ USES=			cmake
 
 DISTNAME=		kitemviews-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/ktreewidgetsearchline.h':" > ${WRKDIR}/TERMS

--- a/bucket_D1/kf5-sonnet/specification
+++ b/bucket_D1/kf5-sonnet/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-sonnet
@@ -38,7 +37,7 @@ USES=			cmake
 
 DISTNAME=		sonnet-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/core/tokenizer_p.h':" > ${WRKDIR}/TERMS

--- a/bucket_D2/kf5-kcoreaddons/specification
+++ b/bucket_D2/kf5-kcoreaddons/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kcoreaddons
@@ -59,7 +58,7 @@ BR_DEPS[openbsd]=	gamin:single:standard
 
 DISTNAME=		kcoreaddons-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-extract:
 	${ECHO} "Terms extracted from 'src/lib/io/kdirwatch.h':" > ${WRKDIR}/TERMS

--- a/bucket_D2/kf5-kcrash/specification
+++ b/bucket_D2/kf5-kcrash/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-kcrash
@@ -38,7 +37,7 @@ USES=			cmake
 
 DISTNAME=		kcrash-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 post-stage:
 	${STRIP_CMD} ${STAGEDIR}${PREFIX}/lib/libKF5Crash.so

--- a/bucket_E9/kf5-solid/specification
+++ b/bucket_E9/kf5-solid/specification
@@ -1,5 +1,4 @@
-DEF[PORTVERSION]=	5.102.0
-DEF[SOVERSION]=		${PORTVERSION}
+DEF[PORTVERSION]=	EXTRACT_INFO(KDE_FRAMEWORKS_VERSION)
 # ----------------------------------------------------------------------------
 
 NAMEBASE=		kf5-solid
@@ -38,7 +37,7 @@ USES=			bison cmake
 
 DISTNAME=		solid-${PORTVERSION}
 CMAKE_ARGS=		-DCMAKE_PREFIX_PATH:PATH={{PREFIX}}/lib/qt5/cmake
-SOVERSION=		${SOVERSION}
+SOVERSION=		${PORTVERSION}
 
 R_DEPS[freebsd]=	bsdisks:single:standard
 


### PR DESCRIPTION
…it, remove LLVM13 version info while there (port is gone)