### PR TITLE
add license field back to comtrya

### DIFF
--- a/bucket_80/comtrya/specification
+++ b/bucket_80/comtrya/specification
@@ -928,10 +928,9 @@ SPKGS[standard]=	single
 OPTIONS_AVAILABLE=	none
 OPTIONS_STANDARD=	none
 
-# License no longer present in tarball
-# LICENSE=		MIT:single
-# LICENSE_FILE=		MIT:{{WRKSRC}}/LICENSE
-# LICENSE_SCHEME=		solo
+LICENSE=		MIT:single
+LICENSE_FILE=		MIT:{{WRKSRC}}/LICENSE
+LICENSE_SCHEME=		solo
 
 USES=			cargo cclibs:single zlib ssl:openssl11 gmake perl:build
 INSTALL_REQ_TOOLCHAIN=	yes

--- a/bucket_80/comtrya/specification.template
+++ b/bucket_80/comtrya/specification.template
@@ -22,10 +22,9 @@ SPKGS[standard]=	single
 OPTIONS_AVAILABLE=	none
 OPTIONS_STANDARD=	none
 
-# License no longer present in tarball
-# LICENSE=		MIT:single
-# LICENSE_FILE=		MIT:{{WRKSRC}}/LICENSE
-# LICENSE_SCHEME=		solo
+LICENSE=		MIT:single
+LICENSE_FILE=		MIT:{{WRKSRC}}/LICENSE
+LICENSE_SCHEME=		solo
 
 USES=			cargo cclibs:single zlib ssl:openssl11 gmake perl:build
 INSTALL_REQ_TOOLCHAIN=	yes


### PR DESCRIPTION
We added it back when @kraileth brought it to my attention that it was left out when the project was split into workspaces.

https://github.com/comtrya/comtrya/commit/0984be459011f09fd052959d251ba3b974a02ef3