### PR TITLE
mesa - fix GLX (fixes #331)

### DIFF
--- a/bucket_F0/mesa/manifests/plist.primary
+++ b/bucket_F0/mesa/manifests/plist.primary
@@ -17,6 +17,9 @@
 lib/libgallium-%%SOVERSION%%.so
 lib/libgbm.so.1
 lib/libgbm.so.1.0.0
+lib/libGLX_mesa.so
+lib/libGLX_mesa.so.0
+lib/libGLX_mesa.so.0.0.0
 lib/dri/nouveau_dri.so
 lib/dri/nouveau_drv_video.so
 lib/dri/virtio_gpu_dri.so

--- a/bucket_F0/mesa/specification
+++ b/bucket_F0/mesa/specification
@@ -6,6 +6,7 @@ DEF[SOVERSION]=		${PORTVERSION}
 
 NAMEBASE=		mesa
 VERSION=		${PORTVERSION}
+REVISION=		1
 KEYWORDS=		graphics
 VARIANTS=		std
 SDESC[std]=		Mesa 3D Graphics Library
@@ -49,6 +50,7 @@ FPC_EQUIVALENT=		graphics/mesa-libs
 BUILD_DEPENDS=		libdrm:dev:std
 			libelf:dev:std
 			libelf:primary:std
+			libglvnd:dev:std
 			libva:dev:std
 			libvdpau:dev:std
 			python-Mako:single:python_used


### PR DESCRIPTION
Fixes: https://github.com/Ravenports/ravensource/issues/331

Prior to this commit, glxinfo would report:

    ~ % glxinfo
    name of display: :0
    Error: couldn't find RGB GLX visual or fbconfig

unless mesa-libs from DPorts (DragonFly ports) were found on the system (pkg ins mesa-libs); chromium from DPorts for example depend on this lib.

ktracing "glxinfo" revealed that it is trying to load libGLX_mesa.so. But the latter is only build if libglvnd is found at build time, so this commit just adds libglvnd as a build-time dependency.

GLVND is the vendor neutral interface for GL.

With this commit in place, "glxinfo" properly works.